### PR TITLE
Fix build for C++17

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -98,7 +98,7 @@ namespace sole
 
 namespace std {
     template<>
-    class hash< sole::uuid > : public std::unary_function< sole::uuid, size_t > {
+    class hash< sole::uuid > {
     public:
         // hash functor: hash uuid to size_t value by pseudorandomizing transform
         size_t operator()( const sole::uuid &uuid ) const {


### PR DESCRIPTION
In C++17, std::unary_function was removed from the standard library. Also, the functor works fine without it.