### PR TITLE
replace MAXHOSTNAMELEN with HOST_NAME_MAX

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -187,9 +187,6 @@ namespace std {
 #   include <sys/time.h>
 #   include <sys/types.h>
 #   include <unistd.h>
-#   if defined(__VMS)
-        namespace { enum { MAXHOSTNAMELEN = 64 }; }
-#   endif
 #   define $unix $yes
 #endif
 
@@ -591,7 +588,7 @@ namespace sole {
     })
 
     $unix({
-        char name[MAXHOSTNAMELEN];
+        char name[HOST_NAME_MAX];
         if (gethostname(name, sizeof(name)))
             return $no("cannot get host name") false;
 


### PR DESCRIPTION
HOST_NAME_MAX is posix-compliant ( see https://pubs.opengroup.org/onlinepubs/9699919799/functions/gethostname.html ), 
MAXHOSTNAMELEN  is not posix-compliant. i guess that's why MAXHOSTNAMELEN  was not available on OpenVMS as well. (i haven't actually checked, but https://www.gnu.org/software/gnulib/manual/html_node/limits_002eh.html suggests that HOST_NAME_MAX  is available on OpenVMS)

also, it was causing Cygwin compilation issues. (there are other cygwin compilation issues as well, but fixing this is a start i guess)