### PR TITLE
Fix last_uuid_time logic

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -457,7 +457,7 @@ namespace sole {
         uuid_time = uuid_time + (tp.tv_nsec / 100);
 
         // If the clock looks like it went backwards, or is the same, increment it.
-        static uint64_t last_uuid_time = 0;
+        static $msvc( __declspec(thread)) $melse( __thread ) uint64_t last_uuid_time = 0;
         if( last_uuid_time >= uuid_time )
             uuid_time = ++last_uuid_time;
         else

--- a/sole.hpp
+++ b/sole.hpp
@@ -459,10 +459,10 @@ namespace sole {
 
         // If the clock looks like it went backwards, or is the same, increment it.
         static uint64_t last_uuid_time = 0;
-        if( last_uuid_time > uuid_time )
-            last_uuid_time = uuid_time;
+        if( last_uuid_time >= uuid_time )
+            uuid_time = ++last_uuid_time;
         else
-            last_uuid_time = ++uuid_time;
+            last_uuid_time = uuid_time;
 
         return uuid_time;
     }

--- a/sole.hpp
+++ b/sole.hpp
@@ -455,7 +455,6 @@ namespace sole {
         uint64_t uuid_time;
         uuid_time = tp.tv_sec * 10000000;
         uuid_time = uuid_time + (tp.tv_nsec / 100);
-        uuid_time = uuid_time + offset;
 
         // If the clock looks like it went backwards, or is the same, increment it.
         static uint64_t last_uuid_time = 0;
@@ -463,6 +462,8 @@ namespace sole {
             uuid_time = ++last_uuid_time;
         else
             last_uuid_time = uuid_time;
+
+        uuid_time = uuid_time + offset;
 
         return uuid_time;
     }


### PR DESCRIPTION
This changes the `get_time` function so that `uuid_time` will always be a value greater than the `last_uuid_time`. I think that's the intent of the code currently, but the logic is wrong.

This also moves the adding of the offset to after the `last_uuid_time` check, so that calling `get_time` from both `uuid0` and `uuid1` will not affect each other.