### PR TITLE
Replace winsock2.h with windows.h to prevent type redefinition error

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -134,7 +134,7 @@ namespace std {
 #include <vector>
 
 #if defined(_WIN32)
-#   include <winsock2.h>
+#   include <windows.h>
 #   include <process.h>
 #   include <iphlpapi.h>
 #   ifdef _MSC_VER


### PR DESCRIPTION
Motivation: https://stackoverflow.com/a/8294669