### PR TITLE
fix clang compilation error

### DIFF
--- a/sole.hpp
+++ b/sole.hpp
@@ -665,8 +665,8 @@ namespace sole {
     // UUID implementations
 
     inline uuid uuid4() {
-        static $msvc(__declspec(thread)) $melse(__thread) std::random_device rd;
-        static $msvc(__declspec(thread)) $melse(__thread) std::uniform_int_distribution<uint64_t> dist(0, (uint64_t)(~0));
+        static $msvc(__declspec(thread)) $melse(thread_local) std::random_device rd;
+        static $msvc(__declspec(thread)) $melse(thread_local) std::uniform_int_distribution<uint64_t> dist(0, (uint64_t)(~0));
 
         uuid my;
 


### PR DESCRIPTION
cannot build by clang: https://godbolt.org/z/6T5ra3bzE
After replace `__thread` with `thread_local`, works fine:
https://godbolt.org/z/hf987KeTa